### PR TITLE
Stop error from appearing on window refresh

### DIFF
--- a/changlelog.md
+++ b/changlelog.md
@@ -4,6 +4,7 @@
 
 ### Additions
  - Added mouse hover tooltips to all buttons on the UI (#4)
+ - Updated the look and feel of the profile buttons (#6)
 
 ### Fixes
  - Fix setup instructions in the README

--- a/changlelog.md
+++ b/changlelog.md
@@ -7,6 +7,7 @@
  - Updated the look and feel of the profile buttons (#6)
 
 ### Fixes
+ - Fix false error message appearing when reloading the window (#7)
  - Fix setup instructions in the README
 
 ## Update 1.1.0 (Dec 4, 2022)

--- a/main.py
+++ b/main.py
@@ -26,7 +26,7 @@ class Profile:
         self.prof_title.pack(side=tk.LEFT, padx=2)
         self.prof_button.pack(side=tk.RIGHT, padx=10)
         self.prof_delete.pack(side=tk.RIGHT)
-        warning_label.pack_forget()
+        if 'warning_label' in globals(): warning_label.pack_forget()
 
     def select_profile(self):
         os.chdir(os.path.dirname(settings['smapi_path']))
@@ -130,8 +130,6 @@ if __name__ == '__main__':
     add_prof_button = tk.CTkButton(window.control_frame, text="+", text_font=("Arial", 18), width=50, command=add_profile)
     add_prof_tooltip = Tooltip(add_prof_button, "Add a new profile")
     add_prof_button.pack(pady=10, anchor=tk.N)
-    warning_label = tk.CTkLabel(window.profiles_list, text="No profiles found, use the + button to add a profile")
-    warning_label.pack(pady=20, padx=100)
 
     if 'smapi_path' not in settings or not os.path.exists(settings['smapi_path']):
         if os.path.exists('C:/Program Files (x86)/Steam/steamapps/common/Stardew Valley/StardewModdingAPI.exe'):
@@ -143,6 +141,9 @@ if __name__ == '__main__':
         save_settings()
 
     load_profiles()
+    if not profiles:
+        warning_label = tk.CTkLabel(window.profiles_list, text="No profiles found, use the + button to add a profile")
+        warning_label.pack(pady=20, padx=100)
 
     window.mainloop()
 


### PR DESCRIPTION
Closes #5 

This PR would fix the bug of a no profiles found error message appearing on the GUI when the window is reloaded, even though there are profiles loaded.