### PR TITLE
Fix UI scaling in different monitor resolutions

### DIFF
--- a/UIelements.py
+++ b/UIelements.py
@@ -9,7 +9,7 @@ class Window(ctk.CTk):
     def __init__(self):
         super().__init__()
         self.title("SMAPI Mod Manager")
-        self.geometry("500x400-1200+1200")
+        self.geometry("500x400")
         self.resizable(False, False)
         self.protocol("WM_DELETE_WINDOW")
 
@@ -20,6 +20,9 @@ class Window(ctk.CTk):
         self.top_frame = Frame(self, width=500, height=200)
         self.top_frame.propagate(False)
         self.top_frame.pack(fill="both", expand=True, side="top", anchor="w")
+        self.banner = PhotoImage(file="assets/background.png")
+        self.banner_label = ctk.CTkLabel(self.top_frame, image=self.banner, width=400, height=200, anchor='nw')
+        self.banner_label.pack(side="left")
 
         # Control buttons (top right)
         self.control_frame = Frame(self.top_frame, width=100, height=200)
@@ -35,10 +38,6 @@ class Window(ctk.CTk):
         self.version_label = ctk.CTkLabel(self.control_frame, text="Version: " + VERSION, width=100, height=20, text_font=("Arial", 7))
         self.version_label.pack(side="bottom", fill="x", pady=5)
         self.control_frame.lift()
-
-        self.banner = PhotoImage(file="assets/background.png")
-        self.banner_label = ctk.CTkLabel(self.top_frame, image=self.banner, width=400, height=200, anchor='nw')
-        self.banner_label.pack(side="left")
 
         # Profiles list (bottom)
         self.canvas = ctk.CTkCanvas(self, bd=0)

--- a/UIelements.py
+++ b/UIelements.py
@@ -5,7 +5,6 @@ import tkinter
 from webbrowser import open as open_url
 
 
-
 class Window(ctk.CTk):
     def __init__(self):
         super().__init__()

--- a/UIelements.py
+++ b/UIelements.py
@@ -5,6 +5,7 @@ import tkinter
 from webbrowser import open as open_url
 
 
+
 class Window(ctk.CTk):
     def __init__(self):
         super().__init__()

--- a/changlelog.md
+++ b/changlelog.md
@@ -3,7 +3,7 @@
 ## Round Tooltip Edges [v1.1.4] (???)
 
 ### Changes
- - Tooltips now have rounded edges
+ - Tooltips now have rounded edges (#16)
  - Made the colour of tooltips brighter so it wouldn't blend in with the background
 
 ## Update [v1.1.3] (Dec 24, 2022)

--- a/changlelog.md
+++ b/changlelog.md
@@ -1,10 +1,14 @@
 # SMAPI Profile Manager Changelog
 
 ## Round Tooltip Edges [v1.1.4] (???)
+Fixed critical issue where the app window would not display properly if your display scaling was not set to 150%, aswell as finally added rounded edges to tooltips.
 
 ### Changes
  - Tooltips now have rounded edges (#16)
  - Made the colour of tooltips brighter so it wouldn't blend in with the background
+
+### Fixes
+ - Fixed issue where the app window would not display properly if your display scaling was not set to 150% (#17)
 
 ## Update [v1.1.3] (Dec 24, 2022)
 Very small update fixing issues with profile names and how they display in the program.

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import customtkinter as tk
 from UIelements import *
 import requests
 import json
+from ctypes import windll
 
 
 class Profile:
@@ -138,6 +139,7 @@ if __name__ == '__main__':
     settings = load_settings()
     # Initialize the TK window
     tk.set_appearance_mode("dark")
+    windll.user32.SetProcessDPIAware()
     window = Window()
     window.add_prof_button.configure(command=add_profile)
 


### PR DESCRIPTION
Closes #13

This PR would fix the issue of the window becoming deformed (proportions change, buttons are cut off, widgets get compacted, etc) when the resolution of the hosting monitor is changed. 