### PR TITLE
New profile selection method

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ This will prompt you to choose a folder, which will be one of your mod profiles.
 Once that is done, you can repeat the process for as many different profiles as you wish. You can then launch the game with different profiles using their launch button, or delete the profile with the delete button.
 
 ## Restrictions
-- The folders of mods when adding profiles currently need to be inside the Stardew Valley folder, this will be fixed soon.
 - The profile manager will only work on Windows (confirmed on Windows 10 only) and will likely never come to other operating systems
 
 ## Modifying the program

--- a/changlelog.md
+++ b/changlelog.md
@@ -1,5 +1,13 @@
 # SMAPI Profile Manager Changelog
 
+# Core Update [v1.2.0] (???)
+
+### Additions
+ - Implemented a new way of loading and saving profiles, leading to fewer errors and less file clutter (#18)
+
+### Changes
+ - Mod profiles can now be imported from anywhere on your computer (#18)
+
 ## Round Tooltip Edges [v1.1.4] (Dec 27, 2022)
 Fixed critical issue where the app window would not display properly if your display scaling was not set to 150%, aswell as finally added rounded edges to tooltips.
 

--- a/main.py
+++ b/main.py
@@ -5,8 +5,7 @@ from UIelements import *
 import requests
 import json
 from ctypes import windll
-import win32com.client
-import subprocess
+from subprocess import call
 
 
 class Profile:
@@ -43,7 +42,7 @@ class Profile:
     def select_profile(self):
         print(f'\"{settings["smapi_path"]}\" \"{self.path}\"')
         cmd = f'\"{settings["smapi_path"]}\" --mods-path \"{self.path}\"'
-        subprocess.call(cmd, shell=True)
+        call(cmd, shell=True)
 
     def delete_profile(self):
         self.prof_frame.destroy()
@@ -136,7 +135,7 @@ if __name__ == '__main__':
     tk.set_appearance_mode("dark")
     windll.user32.SetProcessDPIAware()
     window = Window()
-    window.add_prof_button.configure(command=new_profile)
+    window.add_prof_button.configure(command=add_profile)
 
     if 'smapi_path' not in settings or not os.path.exists(settings['smapi_path']):
         if os.path.exists('C:/Program Files (x86)/Steam/steamapps/common/Stardew Valley/StardewModdingAPI.exe'):

--- a/main.py
+++ b/main.py
@@ -5,6 +5,8 @@ from UIelements import *
 import requests
 import json
 from ctypes import windll
+import win32com.client
+import subprocess
 
 
 class Profile:
@@ -39,18 +41,9 @@ class Profile:
         if 'warning_label' in globals(): warning_label.pack_forget()
 
     def select_profile(self):
-        os.chdir(os.path.dirname(settings['smapi_path']))
-        # Find the name of the profile being disabled
-        try:
-            with open('Mods/profile.txt', 'r') as f:
-                prof_name = f.read()
-            os.system(f'ren "Mods" "Mods_{prof_name}"')
-        except FileNotFoundError:
-            pass
-
-        os.system(f'ren "Mods_{self.name.upper()}" "Mods"')
-
-        os.system(f'START "" "{settings["smapi_path"]}"')
+        print(f'\"{settings["smapi_path"]}\" \"{self.path}\"')
+        cmd = f'\"{settings["smapi_path"]}\" --mods-path \"{self.path}\"'
+        subprocess.call(cmd, shell=True)
 
     def delete_profile(self):
         self.prof_frame.destroy()
@@ -119,6 +112,8 @@ def check_files():
             f.write('{}')
     if not os.path.exists('assets'):
         os.mkdir('assets')
+    if not os.path.exists('profiles'):
+        os.mkdir('profiles')
     if not os.path.exists('assets/background.png'):
         background_img = requests.get('https://github.com/supercam19/SMAPI-Profile-Manager/blob/main/assets/background.png?raw=true')
         with open('assets/background.png', 'wb') as f:
@@ -141,7 +136,7 @@ if __name__ == '__main__':
     tk.set_appearance_mode("dark")
     windll.user32.SetProcessDPIAware()
     window = Window()
-    window.add_prof_button.configure(command=add_profile)
+    window.add_prof_button.configure(command=new_profile)
 
     if 'smapi_path' not in settings or not os.path.exists(settings['smapi_path']):
         if os.path.exists('C:/Program Files (x86)/Steam/steamapps/common/Stardew Valley/StardewModdingAPI.exe'):

--- a/main.py
+++ b/main.py
@@ -41,7 +41,7 @@ class Profile:
 
     def select_profile(self):
         print(f'\"{settings["smapi_path"]}\" \"{self.path}\"')
-        cmd = f'\"{settings["smapi_path"]}\" --mods-path \"{self.path}\"'
+        cmd = f'start cmd /c \"\"{settings["smapi_path"]}\" --mods-path \"{self.path}\"\"'
         call(cmd, shell=True)
 
     def delete_profile(self):

--- a/main.py
+++ b/main.py
@@ -67,8 +67,6 @@ def add_profile():
     prof_name = str(popup_info)
     # set prof_name to the first 100 characters of itself if it is longer than 100 characters
     prof_name = prof_name[:100] if len(prof_name) > 100 else prof_name
-    with open(f'{prof_path}\\profile.txt', 'w') as f:
-        f.write(prof_name.upper())
     profiles.append(Profile(prof_name, prof_path))
     profiles[-1].draw_profile()
     save_profile(prof_name, prof_path)

--- a/main.py
+++ b/main.py
@@ -69,7 +69,6 @@ def add_profile():
     prof_name = prof_name[:100] if len(prof_name) > 100 else prof_name
     with open(f'{prof_path}\\profile.txt', 'w') as f:
         f.write(prof_name.upper())
-    os.system(f'ren "{prof_path}" "Mods_{prof_name.upper()}"')
     profiles.append(Profile(prof_name, prof_path))
     profiles[-1].draw_profile()
     save_profile(prof_name, prof_path)


### PR DESCRIPTION
Closes #10 

This PR implements a new profile selection system by using the SMAPI executable's built in launch arguments to set the mod folder, rather than switching folder names.