### PR TITLE
Change profile info storage to JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ profiles.txt
 smapi.png
 *.zip
 settings.json
+profiles.json

--- a/changlelog.md
+++ b/changlelog.md
@@ -7,6 +7,8 @@
 
 ### Changes
  - Mod profiles can now be imported from anywhere on your computer (#18)
+ - Mod profile information is now stored in a JSON file (#19)
+ - Mod profile creation date and date last played are now tracked (#19)
 
 ## Round Tooltip Edges [v1.1.4] (Dec 27, 2022)
 Fixed critical issue where the app window would not display properly if your display scaling was not set to 150%, aswell as finally added rounded edges to tooltips.

--- a/main.py
+++ b/main.py
@@ -72,19 +72,29 @@ def add_profile():
     save_profile(prof_name, prof_path)
 
 
-def save_profile(name, path):
-    # Write the name and path of the profile to the profiles.txt file
-    with open('profiles.txt', 'a') as f:
-        f.write(f'{name};{path}\n')
+def save_profile(data):
+    with open('profiles.json', 'a') as f:
+        f.truncate(0)
+        json.dump(data, f, indent=4)
 
 
 def load_profiles():
     # Load the users profiles from the profiles.txt file
-    with open('profiles.txt', 'r') as f:
-        for line in f:
-            prof_name, prof_path = line.split(';')
-            profiles.append(Profile(prof_name, prof_path))
-            profiles[-1].draw_profile()
+    with open('profiles.json', 'r') as f:
+        try:
+            profiles_json = json.load(f)
+        except json.decoder.JSONDecodeError:
+            return []
+    return profiles_json
+
+    # profiles.append(Profile(prof_name, prof_path))
+    # profiles[-1].draw_profile()
+
+
+# def load_legacy_profiles():
+#     with open('profiles.txt', 'r') as f:
+#         for line in f:
+#             prof_name, prof_path = line.split(';')
 
 
 def load_settings():
@@ -95,14 +105,14 @@ def load_settings():
 
 def save_settings():
     with open('settings.json', 'w') as f:
-        json.dump(settings, f)
+        json.dump(settings, f, indent=4)
 
 
 def check_files():
     # Check if critical files are missing, if so, download/create them
     if not os.path.exists('profiles.json'):
         with open('profiles.json', 'w') as f:
-            f.write('{}')
+            f.write('')
     if not os.path.exists('settings.json'):
         with open('settings.json', 'w') as f:
             f.write('{}')
@@ -143,7 +153,14 @@ if __name__ == '__main__':
             settings['smapi_path'] = filedialog.askopenfilename(title="Select StardewModdingAPI.exe", filetypes=[("StardewModdingAPI.exe", "*.exe")])
         save_settings()
 
-    load_profiles()
+    profiles_data = load_profiles()
+    for profile in profiles_data:
+        profiles.append(Profile(profile['name'], profile['path']))
+        profiles[-1].draw_profile()
+
+    profiles_data.append({"name": "test", "path": "test"})
+    save_profile(profiles_data)
+
     if not profiles:
         warning_label = tk.CTkLabel(window.profiles_list, text="No profiles found, use the + button to add a profile")
         warning_label.pack(pady=20, padx=100)

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ import requests
 import json
 from ctypes import windll
 from subprocess import call
+from time import time
 
 
 class Profile:
@@ -66,6 +67,7 @@ def add_profile():
     prof_name = prof_name[:100] if len(prof_name) > 100 else prof_name
     profiles.append(Profile(prof_name, prof_path))
     profiles[-1].draw_profile()
+    profiles_data.append({'name': prof_name, 'path': prof_path, 'created': int(time())})
     save_profile(profiles_data)
 
 
@@ -91,7 +93,7 @@ def convert_legacy_profiles():
     with open('profiles.txt', 'r') as f:
         for line in f:
             prof_name, prof_path = line.split(';')
-            profiles_data.append({'name': prof_name, 'path': prof_path})
+            profiles_data.append({'name': prof_name, 'path': prof_path, 'created': int(time())})
     save_profile(profiles_data)
     os.remove('profiles.txt')
 

--- a/main.py
+++ b/main.py
@@ -91,10 +91,16 @@ def load_profiles():
     # profiles[-1].draw_profile()
 
 
-# def load_legacy_profiles():
-#     with open('profiles.txt', 'r') as f:
-#         for line in f:
-#             prof_name, prof_path = line.split(';')
+def convert_legacy_profiles():
+    """
+    Automatically converts profiles stored in the old format to the new format
+    """
+    with open('profiles.txt', 'r') as f:
+        for line in f:
+            prof_name, prof_path = line.split(';')
+            profiles_data.append({'name': prof_name, 'path': prof_path})
+    save_profile(profiles_data)
+    os.remove('profiles.txt')
 
 
 def load_settings():
@@ -153,6 +159,7 @@ if __name__ == '__main__':
             settings['smapi_path'] = filedialog.askopenfilename(title="Select StardewModdingAPI.exe", filetypes=[("StardewModdingAPI.exe", "*.exe")])
         save_settings()
 
+    if os.path.exists('profiles.txt'): convert_legacy_profiles()
     profiles_data = load_profiles()
     for profile in profiles_data:
         profiles.append(Profile(profile['name'], profile['path']))

--- a/main.py
+++ b/main.py
@@ -100,9 +100,9 @@ def save_settings():
 
 def check_files():
     # Check if critical files are missing, if so, download/create them
-    if not os.path.exists('profiles.txt'):
-        with open('profiles.txt', 'w') as f:
-            f.write('')
+    if not os.path.exists('profiles.json'):
+        with open('profiles.json', 'w') as f:
+            f.write('{}')
     if not os.path.exists('settings.json'):
         with open('settings.json', 'w') as f:
             f.write('{}')

--- a/main.py
+++ b/main.py
@@ -41,6 +41,10 @@ class Profile:
         if 'warning_label' in globals(): warning_label.pack_forget()
 
     def select_profile(self):
+        for profile in profiles_data:
+            if profile['name'] == self.name:
+                profile['last-launch'] = int(time())
+                save_profile(profiles_data)
         cmd = f'start cmd /c \"\"{settings["smapi_path"]}\" --mods-path \"{self.path}\"\"'
         call(cmd, shell=True)
 

--- a/main.py
+++ b/main.py
@@ -40,7 +40,6 @@ class Profile:
         if 'warning_label' in globals(): warning_label.pack_forget()
 
     def select_profile(self):
-        print(f'\"{settings["smapi_path"]}\" \"{self.path}\"')
         cmd = f'start cmd /c \"\"{settings["smapi_path"]}\" --mods-path \"{self.path}\"\"'
         call(cmd, shell=True)
 
@@ -50,12 +49,10 @@ class Profile:
         self.prof_button.destroy()
         self.prof_delete.destroy()
         # Remove the profile from the text file
-        with open('profiles.txt', 'r') as f:
-            lines = f.readlines()
-        with open('profiles.txt', 'w') as f:
-            for line in lines:
-                if not line.startswith(self.name):
-                    f.write(line)
+        for profile in profiles_data:
+            if profile['name'] == self.name:
+                profiles_data.remove(profile)
+        save_profile(profiles_data)
 
 
 def add_profile():
@@ -69,7 +66,7 @@ def add_profile():
     prof_name = prof_name[:100] if len(prof_name) > 100 else prof_name
     profiles.append(Profile(prof_name, prof_path))
     profiles[-1].draw_profile()
-    save_profile(prof_name, prof_path)
+    save_profile(profiles_data)
 
 
 def save_profile(data):
@@ -79,16 +76,12 @@ def save_profile(data):
 
 
 def load_profiles():
-    # Load the users profiles from the profiles.txt file
     with open('profiles.json', 'r') as f:
         try:
             profiles_json = json.load(f)
         except json.decoder.JSONDecodeError:
             return []
     return profiles_json
-
-    # profiles.append(Profile(prof_name, prof_path))
-    # profiles[-1].draw_profile()
 
 
 def convert_legacy_profiles():
@@ -144,6 +137,7 @@ VERSION = "v1.1.4"
 if __name__ == '__main__':
     check_files()
     settings = load_settings()
+    profiles_data = []
     # Initialize the TK window
     tk.set_appearance_mode("dark")
     windll.user32.SetProcessDPIAware()
@@ -164,9 +158,6 @@ if __name__ == '__main__':
     for profile in profiles_data:
         profiles.append(Profile(profile['name'], profile['path']))
         profiles[-1].draw_profile()
-
-    profiles_data.append({"name": "test", "path": "test"})
-    save_profile(profiles_data)
 
     if not profiles:
         warning_label = tk.CTkLabel(window.profiles_list, text="No profiles found, use the + button to add a profile")


### PR DESCRIPTION
Closes #11 

This PR would change the profile information storage method from a custom one to JSON. 

- [x] Implement profiles.json file check
- [x] Change profile loader to use JSON
- [x] Change profile saver to use JSON
- [x] Automatically convert legacy profiles to the new format
- [x] Store more data points
  - [x] Profile creation date
  - [x] Profile last launched date
- [x] Update changelog