### PR TITLE
Allow profiles list to be sorted

### DIFF
--- a/UIelements.py
+++ b/UIelements.py
@@ -6,7 +6,7 @@ from webbrowser import open as open_url
 
 
 class Window(ctk.CTk):
-    def __init__(self, sort_callback=None):
+    def __init__(self, settings, sort_callback=None):
         super().__init__()
         self.sort_callback = sort_callback
         self.title("SMAPI Mod Manager")
@@ -40,7 +40,7 @@ class Window(ctk.CTk):
         self.version_label.pack(side="bottom", fill="x", pady=5)
         self.control_frame.lift()
 
-        # Profiles list (bottom)
+        # Sorting bar
         self.sorting_frame = Frame(self, width=500, height=30)
         self.sorting_frame.propagate(False)
         self.sorting_frame.pack(fill="both", expand=True, side="top", anchor="w")
@@ -48,10 +48,16 @@ class Window(ctk.CTk):
         self.sorting_label.pack(side="left", anchor="w", padx=(30, 15), pady=5)
         self.sorting_dropdown = ctk.CTkOptionMenu(self.sorting_frame, width=100, height=20, text_font=("Arial", 12), values=["Name", "Last Played", "Created"], command=self.sort_callback)
         self.sorting_dropdown.pack(side="left", anchor="w", pady=5)
-        self.sorting_dropdown.set("Name")
+        if 'sort' in settings:
+            self.sorting_dropdown.set(settings['sort'])
+        else:
+            self.sorting_dropdown.set("Name")
         self.invert_sort_checkbox = ctk.CTkCheckBox(self.sorting_frame, text="Invert", width=20, height=20, text_font=("Arial", 12), command=self.sort_callback)
         self.invert_sort_checkbox.pack(side="left", anchor="w", padx=15, pady=5)
+        if 'invert' in settings:
+            self.invert_sort_checkbox.select() if settings['invert'] else self.invert_sort_checkbox.deselect()
 
+        # Profiles list (bottom)
         self.canvas = ctk.CTkCanvas(self, bd=0)
         self.profiles_list = Frame(self, width=500, height=320)
         self.scrollbar = ctk.CTkScrollbar(self.profiles_list, command=self.canvas.yview)

--- a/UIelements.py
+++ b/UIelements.py
@@ -6,8 +6,9 @@ from webbrowser import open as open_url
 
 
 class Window(ctk.CTk):
-    def __init__(self):
+    def __init__(self, sort_callback=None):
         super().__init__()
+        self.sort_callback = sort_callback
         self.title("SMAPI Mod Manager")
         self.geometry("500x400")
         self.resizable(False, False)
@@ -40,8 +41,19 @@ class Window(ctk.CTk):
         self.control_frame.lift()
 
         # Profiles list (bottom)
+        self.sorting_frame = Frame(self, width=500, height=30)
+        self.sorting_frame.propagate(False)
+        self.sorting_frame.pack(fill="both", expand=True, side="top", anchor="w")
+        self.sorting_label = ctk.CTkLabel(self.sorting_frame, text="Sort:", height=20, text_font=("Arial", 12), anchor="e")
+        self.sorting_label.pack(side="left", anchor="w", padx=(30, 15), pady=5)
+        self.sorting_dropdown = ctk.CTkOptionMenu(self.sorting_frame, width=100, height=20, text_font=("Arial", 12), values=["Name", "Last Played", "Created"], command=self.sort_callback)
+        self.sorting_dropdown.pack(side="left", anchor="w", pady=5)
+        self.sorting_dropdown.set("Name")
+        self.invert_sort_checkbox = ctk.CTkCheckBox(self.sorting_frame, text="Invert", width=20, height=20, text_font=("Arial", 12), command=self.sort_callback)
+        self.invert_sort_checkbox.pack(side="left", anchor="w", padx=15, pady=5)
+
         self.canvas = ctk.CTkCanvas(self, bd=0)
-        self.profiles_list = Frame(self, width=500, height=360)
+        self.profiles_list = Frame(self, width=500, height=320)
         self.scrollbar = ctk.CTkScrollbar(self.profiles_list, command=self.canvas.yview)
         self.canvas.configure(yscrollcommand=self.scrollbar.set)
         self.canvas.pack(side="left")

--- a/changlelog.md
+++ b/changlelog.md
@@ -4,7 +4,7 @@
 
 ### Additions
  - Profiles can now be edited, and an editor has been added to the UI (#20)
- - 
+ - The profiles list can now be sorted by name, date created, and date last played (#22)
  - Added a default profile that launches the game unmodded (#21)
  - Implemented a new way of loading and saving profiles, leading to fewer errors and less file clutter (#18)
 

--- a/changlelog.md
+++ b/changlelog.md
@@ -4,6 +4,7 @@
 
 ### Additions
  - Profiles can now be edited, and an editor has been added to the UI (#20)
+ - 
  - Added a default profile that launches the game unmodded (#21)
  - Implemented a new way of loading and saving profiles, leading to fewer errors and less file clutter (#18)
 

--- a/main.py
+++ b/main.py
@@ -228,7 +228,7 @@ if __name__ == '__main__':
     # Initialize the TK window
     tk.set_appearance_mode("dark")
     windll.user32.SetProcessDPIAware()
-    window = Window(sort_callback=sort_profiles)
+    window = Window(settings, sort_callback=sort_profiles)
     window.add_prof_button.configure(command=add_profile)
 
     if 'smapi_path' not in settings or not os.path.exists(settings['smapi_path']):
@@ -245,7 +245,10 @@ if __name__ == '__main__':
     if 'force_smapi' not in profiles_data[0]: profiles_data.insert(0, {'name': 'Unmodded', 'force_smapi': False, 'special': 'unmodded', 'created': int(time())})
     for profile in profiles_data:
         profiles.append(Profile(profile))
-    sort_profiles('Name')
+    if 'sort' in settings:
+        sort_profiles(settings['sort'])
+    else:
+        sort_profiles('Name')
     for profile in profiles:
         profile.draw_profile()
 

--- a/main.py
+++ b/main.py
@@ -193,9 +193,6 @@ def check_files():
 
 
 def sort_profiles(sort=None):
-    def sort_by_name(profile):
-        return profile.name
-
     invert = window.invert_sort_checkbox.get()
     unmodded = profiles[0]
     profiles.pop(0)
@@ -214,6 +211,10 @@ def sort_profiles(sort=None):
         profile.hide_profile()
     for profile in profiles:
         profile.draw_profile()
+
+    if sort is not None: settings['sort'] = sort
+    settings['invert'] = invert
+    save_settings()
 
 
 profiles = []

--- a/main.py
+++ b/main.py
@@ -17,6 +17,8 @@ class Profile:
         self.special = info['special']
         self.prof_info = info # all other profile information
         if 'last_launched' not in self.prof_info: self.prof_info['last_launched'] = -1
+        self.created = info['created']
+        self.last_launched = info['last_launched']
         self.prof_frame = tk.CTkFrame(window.profiles_list, width=480, height=32)
         self.prof_frame.pack_propagate(False)
         self.left_frame = tk.CTkFrame(self.prof_frame, width=320, height=32, fg_color='gray21', bg_color='gray21')
@@ -42,6 +44,13 @@ class Profile:
         if self.special != 'unmodded': self.prof_delete.pack(side=tk.RIGHT)
         self.right_frame.pack(side='right')
         if 'warning_label' in globals(): warning_label.pack_forget()
+
+    def hide_profile(self):
+        self.prof_frame.pack_forget()
+        self.prof_title.pack_forget()
+        self.prof_button.pack_forget()
+        self.prof_edit.pack_forget()
+        self.prof_delete.pack_forget()
 
     def select_profile(self):
         edit_saved_profile(self.name, int(time()), key='last_used')
@@ -183,6 +192,36 @@ def check_files():
             f.write(icon_img.content)
 
 
+def sort_profiles(sort=None):
+    def sort_by_name(profile):
+        return profile.name
+    print(sort)
+
+    invert = window.invert_sort_checkbox.get()
+    unmodded = profiles[0]
+    profiles.pop(0)
+    if sort is None:
+        profiles.reverse()
+        profiles.insert(0, unmodded)
+    else:
+        if sort == 'Name':
+            profiles.sort(key=lambda x: x.name, reverse=invert)
+        elif sort == 'Created':
+            print('sort by created')
+            profiles.sort(key=lambda x: x.created, reverse=invert)
+        elif sort == 'Last Played':
+            print('last played')
+            profiles.sort(key=lambda x: x.last_launched, reverse=invert)
+        profiles.insert(0, unmodded)
+    for profile in profiles:
+        profile.hide_profile()
+    for profile in profiles:
+        profile.draw_profile()
+    print(profiles)
+
+
+
+
 profiles = []
 name_input = ''
 VERSION = "v1.1.4"
@@ -194,7 +233,7 @@ if __name__ == '__main__':
     # Initialize the TK window
     tk.set_appearance_mode("dark")
     windll.user32.SetProcessDPIAware()
-    window = Window()
+    window = Window(sort_callback=sort_profiles)
     window.add_prof_button.configure(command=add_profile)
 
     if 'smapi_path' not in settings or not os.path.exists(settings['smapi_path']):
@@ -208,10 +247,12 @@ if __name__ == '__main__':
 
     if os.path.exists('profiles.txt'): convert_legacy_profiles()
     profiles_data = load_profiles()
-    if 'force_smapi' not in profiles_data[0]: profiles_data.insert(0, {'name': 'Unmodded', 'force_smapi': False, 'special': 'unmodded'})
+    if 'force_smapi' not in profiles_data[0]: profiles_data.insert(0, {'name': 'Unmodded', 'force_smapi': False, 'special': 'unmodded', 'created': int(time())})
     for profile in profiles_data:
         profiles.append(Profile(profile))
-        profiles[-1].draw_profile()
+    sort_profiles('Name')
+    for profile in profiles:
+        profile.draw_profile()
 
     if not profiles:
         warning_label = tk.CTkLabel(window.profiles_list, text="No profiles found, use the + button to add a profile")

--- a/main.py
+++ b/main.py
@@ -195,7 +195,6 @@ def check_files():
 def sort_profiles(sort=None):
     def sort_by_name(profile):
         return profile.name
-    print(sort)
 
     invert = window.invert_sort_checkbox.get()
     unmodded = profiles[0]
@@ -207,19 +206,14 @@ def sort_profiles(sort=None):
         if sort == 'Name':
             profiles.sort(key=lambda x: x.name, reverse=invert)
         elif sort == 'Created':
-            print('sort by created')
             profiles.sort(key=lambda x: x.created, reverse=invert)
         elif sort == 'Last Played':
-            print('last played')
             profiles.sort(key=lambda x: x.last_launched, reverse=invert)
         profiles.insert(0, unmodded)
     for profile in profiles:
         profile.hide_profile()
     for profile in profiles:
         profile.draw_profile()
-    print(profiles)
-
-
 
 
 profiles = []


### PR DESCRIPTION
Closes #12 

This PR would add a feature allowing users to sort their profiles list by things such as name (alphabetical), date created, and date last launched (possibly more too). The sorting should also be able to be reversed (ie: names would sort Z-A).

- [x] Create sorting bar on the UI
- [x] Add sorting logic
- [x] Allow reversed sorting
- [x] Save the how the profiles are sorted into settings.json
- [x] Update changelog