### PR TITLE
Allow profiles to be undeleted

### DIFF
--- a/UIelements.py
+++ b/UIelements.py
@@ -88,6 +88,37 @@ class Window(ctk.CTk):
         if mouse_y > 360:
             self.canvas.yview_scroll(-1 * int((event.delta / 120)), "units")
 
+    def update_bar(self, new_ver, dont_show_callback):
+        self.msg_frame = Frame(self, fg_color='blue', bg_color='blue')
+        self.msg_frame.pack(side='bottom', fill='x')
+        msg = ctk.CTkLabel(self.msg_frame, text=f'New version available: {new_ver}', text_font=('Arial', 8))
+        msg.pack(side='left', padx=(2, 0))
+
+        # Link to download the newest release
+        download_button = ctk.CTkButton(self.msg_frame, text='| Download', command=lambda: open_url('https://github.com/supercam19/SMAPI-Profile-Manager/releases/latest'),
+                                        fg_color='blue', text_font=('Arial', 8), hover_color='#0000DD', width=1)
+        download_button.pack(side='left')
+        download_button.bind('<Enter>', lambda e: download_button.configure(text_font=('Arial', 8, 'underline')))
+        download_button.bind('<Leave>', lambda e: download_button.configure(text_font=('Arial', 8)))
+
+        # Don't show new version message again
+        dont_show_button = ctk.CTkButton(self.msg_frame, text='| Don\'t show again', command=lambda: self.dont_show_update_bar_again(dont_show_callback),
+                                         fg_color='blue', text_font=('Arial', 8), hover_color='#0000DD', width=1)
+        dont_show_button.pack(side='left')
+        dont_show_button.bind('<Enter>', lambda e: dont_show_button.configure(text_font=('Arial', 8, 'underline')))
+        dont_show_button.bind('<Leave>', lambda e: dont_show_button.configure(text_font=('Arial', 8)))
+
+        hide_button = ctk.CTkButton(self.msg_frame, text='x', command=self.hide_update_bar, fg_color='blue', text_font=('Arial', 12), hover_color='#0000DD', width=1)
+        hide_button.pack(side='right', padx=5)
+
+    def dont_show_update_bar_again(self, callback):
+        self.hide_update_bar()
+        callback()
+
+    def hide_update_bar(self):
+        self.msg_frame.pack_forget()
+
+
 
 class Frame(ctk.CTkFrame):
     # Frame object (just a regular CTkFrame)
@@ -131,45 +162,6 @@ class Button(ctk.CTkButton):
             self.configure(text_color=self.text_color_default)
         elif self.type == 'button':
             self.configure(image=self.image_default)
-
-
-class BarPopup:
-    def __init__(self, window):
-        self.msg_frame = Frame(window, fg_color='blue', bg_color='blue')
-        self.msg_frame.pack(side='bottom', fill='x')
-
-    def dont_show_update_bar_again(self, callback):
-        self.hide_update_bar()
-        callback()
-
-    def hide_update_bar(self):
-        self.msg_frame.pack_forget()
-
-    def set_update_preset(self, new_ver, dont_show_callback):
-        msg = ctk.CTkLabel(self.msg_frame, text=f'New version available: {new_ver}', text_font=('Arial', 8))
-        msg.pack(side='left', padx=(2, 0))
-
-        # Link to download the newest release
-        download_button = ctk.CTkButton(self.msg_frame, text='| Download', command=lambda: open_url('https://github.com/supercam19/SMAPI-Profile-Manager/releases/latest'),
-                                        fg_color='blue', text_font=('Arial', 8), hover_color='#0000DD', width=1)
-        download_button.pack(side='left')
-        download_button.bind('<Enter>', lambda e: download_button.configure(text_font=('Arial', 8, 'underline')))
-        download_button.bind('<Leave>', lambda e: download_button.configure(text_font=('Arial', 8)))
-
-        # Don't show new version message again
-        dont_show_button = ctk.CTkButton(self.msg_frame, text='| Don\'t show again', command=lambda: self.dont_show_update_bar_again(dont_show_callback),
-                                         fg_color='blue', text_font=('Arial', 8), hover_color='#0000DD', width=1)
-        dont_show_button.pack(side='left')
-        dont_show_button.bind('<Enter>', lambda e: dont_show_button.configure(text_font=('Arial', 8, 'underline')))
-        dont_show_button.bind('<Leave>', lambda e: dont_show_button.configure(text_font=('Arial', 8)))
-
-        hide_button = ctk.CTkButton(self.msg_frame, text='x', command=self.hide_update_bar, fg_color='blue', text_font=('Arial', 12), hover_color='#0000DD', width=1)
-        hide_button.pack(side='right', padx=5)
-
-    def set_profile_delete_preset(self):
-        pass
-
-
 
 
 class Popup:

--- a/UIelements.py
+++ b/UIelements.py
@@ -41,6 +41,9 @@ class Window(ctk.CTk):
         self.add_prof_button = ctk.CTkButton(self.control_frame, text="+", text_font=("Arial", 18), width=50,)
         self.add_prof_tooltip = Tooltip(self.add_prof_button, "Add a new profile")
         self.add_prof_button.pack(pady=(10, 5), anchor=ctk.N)
+        self.undo_button = ctk.CTkButton(self.control_frame, text="\U000021A9", text_font=("Arial", 18), width=50, state="disabled")
+        self.undo_tooltip = Tooltip(self.undo_button, "Revert last change to profiles")
+        self.undo_button.pack(pady=5, anchor=ctk.N)
         self.github_button = ctk.CTkButton(self.control_frame, text="\U0001F6C8", text_color='white', text_font=("Arial", 20),
                                            width=50, command=lambda: open_url("https://github.com/supercam19/SMAPI-Profile-Manager"), pady=0)
         self.github_tooltip = Tooltip(self.github_button, "Help (Open GitHub page)")

--- a/UIelements.py
+++ b/UIelements.py
@@ -137,42 +137,39 @@ class BarPopup:
     def __init__(self, window):
         self.msg_frame = Frame(window, fg_color='blue', bg_color='blue')
         self.msg_frame.pack(side='bottom', fill='x')
-        self.preset = self.Preset(self.msg_frame)
 
-    class Preset:
-        def __init__(self, msg_frame):
-            self.msg_frame = msg_frame
+    def dont_show_update_bar_again(self, callback):
+        self.hide_update_bar()
+        callback()
 
-        def set_new_update(self, new_ver, dont_show_callback):
-            msg = ctk.CTkLabel(self.msg_frame, text=f'New version available: {new_ver}', text_font=('Arial', 8))
-            msg.pack(side='left', padx=(2, 0))
+    def hide_update_bar(self):
+        self.msg_frame.pack_forget()
 
-            # Link to download the newest release
-            download_button = ctk.CTkButton(self.msg_frame, text='| Download', command=lambda: open_url('https://github.com/supercam19/SMAPI-Profile-Manager/releases/latest'),
-                                            fg_color='blue', text_font=('Arial', 8), hover_color='#0000DD', width=1)
-            download_button.pack(side='left')
-            download_button.bind('<Enter>', lambda e: download_button.configure(text_font=('Arial', 8, 'underline')))
-            download_button.bind('<Leave>', lambda e: download_button.configure(text_font=('Arial', 8)))
+    def set_update_preset(self, new_ver, dont_show_callback):
+        msg = ctk.CTkLabel(self.msg_frame, text=f'New version available: {new_ver}', text_font=('Arial', 8))
+        msg.pack(side='left', padx=(2, 0))
 
-            # Don't show new version message again
-            dont_show_button = ctk.CTkButton(self.msg_frame, text='| Don\'t show again', command=lambda: self.dont_show_update_bar_again(dont_show_callback),
-                                             fg_color='blue', text_font=('Arial', 8), hover_color='#0000DD', width=1)
-            dont_show_button.pack(side='left')
-            dont_show_button.bind('<Enter>', lambda e: dont_show_button.configure(text_font=('Arial', 8, 'underline')))
-            dont_show_button.bind('<Leave>', lambda e: dont_show_button.configure(text_font=('Arial', 8)))
+        # Link to download the newest release
+        download_button = ctk.CTkButton(self.msg_frame, text='| Download', command=lambda: open_url('https://github.com/supercam19/SMAPI-Profile-Manager/releases/latest'),
+                                        fg_color='blue', text_font=('Arial', 8), hover_color='#0000DD', width=1)
+        download_button.pack(side='left')
+        download_button.bind('<Enter>', lambda e: download_button.configure(text_font=('Arial', 8, 'underline')))
+        download_button.bind('<Leave>', lambda e: download_button.configure(text_font=('Arial', 8)))
 
-            hide_button = ctk.CTkButton(self.msg_frame, text='x', command=self.hide_update_bar, fg_color='blue', text_font=('Arial', 12), hover_color='#0000DD', width=1)
-            hide_button.pack(side='right', padx=5)
+        # Don't show new version message again
+        dont_show_button = ctk.CTkButton(self.msg_frame, text='| Don\'t show again', command=lambda: self.dont_show_update_bar_again(dont_show_callback),
+                                         fg_color='blue', text_font=('Arial', 8), hover_color='#0000DD', width=1)
+        dont_show_button.pack(side='left')
+        dont_show_button.bind('<Enter>', lambda e: dont_show_button.configure(text_font=('Arial', 8, 'underline')))
+        dont_show_button.bind('<Leave>', lambda e: dont_show_button.configure(text_font=('Arial', 8)))
 
-        def dont_show_update_bar_again(self, callback):
-            self.hide_update_bar()
-            callback()
+        hide_button = ctk.CTkButton(self.msg_frame, text='x', command=self.hide_update_bar, fg_color='blue', text_font=('Arial', 12), hover_color='#0000DD', width=1)
+        hide_button.pack(side='right', padx=5)
 
-        def hide_update_bar(self):
-            self.msg_frame.pack_forget()
+    def set_profile_delete_preset(self):
+        pass
 
-        def set_profile_delete(self):
-            pass
+
 
 
 class Popup:

--- a/UIelements.py
+++ b/UIelements.py
@@ -137,39 +137,42 @@ class BarPopup:
     def __init__(self, window):
         self.msg_frame = Frame(window, fg_color='blue', bg_color='blue')
         self.msg_frame.pack(side='bottom', fill='x')
+        self.preset = self.Preset(self.msg_frame)
 
-    def dont_show_update_bar_again(self, callback):
-        self.hide_update_bar()
-        callback()
+    class Preset:
+        def __init__(self, msg_frame):
+            self.msg_frame = msg_frame
 
-    def hide_update_bar(self):
-        self.msg_frame.pack_forget()
+        def set_new_update(self, new_ver, dont_show_callback):
+            msg = ctk.CTkLabel(self.msg_frame, text=f'New version available: {new_ver}', text_font=('Arial', 8))
+            msg.pack(side='left', padx=(2, 0))
 
-    def set_update_preset(self, new_ver, dont_show_callback):
-        msg = ctk.CTkLabel(self.msg_frame, text=f'New version available: {new_ver}', text_font=('Arial', 8))
-        msg.pack(side='left', padx=(2, 0))
+            # Link to download the newest release
+            download_button = ctk.CTkButton(self.msg_frame, text='| Download', command=lambda: open_url('https://github.com/supercam19/SMAPI-Profile-Manager/releases/latest'),
+                                            fg_color='blue', text_font=('Arial', 8), hover_color='#0000DD', width=1)
+            download_button.pack(side='left')
+            download_button.bind('<Enter>', lambda e: download_button.configure(text_font=('Arial', 8, 'underline')))
+            download_button.bind('<Leave>', lambda e: download_button.configure(text_font=('Arial', 8)))
 
-        # Link to download the newest release
-        download_button = ctk.CTkButton(self.msg_frame, text='| Download', command=lambda: open_url('https://github.com/supercam19/SMAPI-Profile-Manager/releases/latest'),
-                                        fg_color='blue', text_font=('Arial', 8), hover_color='#0000DD', width=1)
-        download_button.pack(side='left')
-        download_button.bind('<Enter>', lambda e: download_button.configure(text_font=('Arial', 8, 'underline')))
-        download_button.bind('<Leave>', lambda e: download_button.configure(text_font=('Arial', 8)))
+            # Don't show new version message again
+            dont_show_button = ctk.CTkButton(self.msg_frame, text='| Don\'t show again', command=lambda: self.dont_show_update_bar_again(dont_show_callback),
+                                             fg_color='blue', text_font=('Arial', 8), hover_color='#0000DD', width=1)
+            dont_show_button.pack(side='left')
+            dont_show_button.bind('<Enter>', lambda e: dont_show_button.configure(text_font=('Arial', 8, 'underline')))
+            dont_show_button.bind('<Leave>', lambda e: dont_show_button.configure(text_font=('Arial', 8)))
 
-        # Don't show new version message again
-        dont_show_button = ctk.CTkButton(self.msg_frame, text='| Don\'t show again', command=lambda: self.dont_show_update_bar_again(dont_show_callback),
-                                         fg_color='blue', text_font=('Arial', 8), hover_color='#0000DD', width=1)
-        dont_show_button.pack(side='left')
-        dont_show_button.bind('<Enter>', lambda e: dont_show_button.configure(text_font=('Arial', 8, 'underline')))
-        dont_show_button.bind('<Leave>', lambda e: dont_show_button.configure(text_font=('Arial', 8)))
+            hide_button = ctk.CTkButton(self.msg_frame, text='x', command=self.hide_update_bar, fg_color='blue', text_font=('Arial', 12), hover_color='#0000DD', width=1)
+            hide_button.pack(side='right', padx=5)
 
-        hide_button = ctk.CTkButton(self.msg_frame, text='x', command=self.hide_update_bar, fg_color='blue', text_font=('Arial', 12), hover_color='#0000DD', width=1)
-        hide_button.pack(side='right', padx=5)
+        def dont_show_update_bar_again(self, callback):
+            self.hide_update_bar()
+            callback()
 
-    def set_profile_delete_preset(self):
-        pass
+        def hide_update_bar(self):
+            self.msg_frame.pack_forget()
 
-
+        def set_profile_delete(self):
+            pass
 
 
 class Popup:

--- a/UIelements.py
+++ b/UIelements.py
@@ -88,37 +88,6 @@ class Window(ctk.CTk):
         if mouse_y > 360:
             self.canvas.yview_scroll(-1 * int((event.delta / 120)), "units")
 
-    def update_bar(self, new_ver, dont_show_callback):
-        self.msg_frame = Frame(self, fg_color='blue', bg_color='blue')
-        self.msg_frame.pack(side='bottom', fill='x')
-        msg = ctk.CTkLabel(self.msg_frame, text=f'New version available: {new_ver}', text_font=('Arial', 8))
-        msg.pack(side='left', padx=(2, 0))
-
-        # Link to download the newest release
-        download_button = ctk.CTkButton(self.msg_frame, text='| Download', command=lambda: open_url('https://github.com/supercam19/SMAPI-Profile-Manager/releases/latest'),
-                                        fg_color='blue', text_font=('Arial', 8), hover_color='#0000DD', width=1)
-        download_button.pack(side='left')
-        download_button.bind('<Enter>', lambda e: download_button.configure(text_font=('Arial', 8, 'underline')))
-        download_button.bind('<Leave>', lambda e: download_button.configure(text_font=('Arial', 8)))
-
-        # Don't show new version message again
-        dont_show_button = ctk.CTkButton(self.msg_frame, text='| Don\'t show again', command=lambda: self.dont_show_update_bar_again(dont_show_callback),
-                                         fg_color='blue', text_font=('Arial', 8), hover_color='#0000DD', width=1)
-        dont_show_button.pack(side='left')
-        dont_show_button.bind('<Enter>', lambda e: dont_show_button.configure(text_font=('Arial', 8, 'underline')))
-        dont_show_button.bind('<Leave>', lambda e: dont_show_button.configure(text_font=('Arial', 8)))
-
-        hide_button = ctk.CTkButton(self.msg_frame, text='x', command=self.hide_update_bar, fg_color='blue', text_font=('Arial', 12), hover_color='#0000DD', width=1)
-        hide_button.pack(side='right', padx=5)
-
-    def dont_show_update_bar_again(self, callback):
-        self.hide_update_bar()
-        callback()
-
-    def hide_update_bar(self):
-        self.msg_frame.pack_forget()
-
-
 
 class Frame(ctk.CTkFrame):
     # Frame object (just a regular CTkFrame)
@@ -162,6 +131,45 @@ class Button(ctk.CTkButton):
             self.configure(text_color=self.text_color_default)
         elif self.type == 'button':
             self.configure(image=self.image_default)
+
+
+class BarPopup:
+    def __init__(self, window):
+        self.msg_frame = Frame(window, fg_color='blue', bg_color='blue')
+        self.msg_frame.pack(side='bottom', fill='x')
+
+    def dont_show_update_bar_again(self, callback):
+        self.hide_update_bar()
+        callback()
+
+    def hide_update_bar(self):
+        self.msg_frame.pack_forget()
+
+    def set_update_preset(self, new_ver, dont_show_callback):
+        msg = ctk.CTkLabel(self.msg_frame, text=f'New version available: {new_ver}', text_font=('Arial', 8))
+        msg.pack(side='left', padx=(2, 0))
+
+        # Link to download the newest release
+        download_button = ctk.CTkButton(self.msg_frame, text='| Download', command=lambda: open_url('https://github.com/supercam19/SMAPI-Profile-Manager/releases/latest'),
+                                        fg_color='blue', text_font=('Arial', 8), hover_color='#0000DD', width=1)
+        download_button.pack(side='left')
+        download_button.bind('<Enter>', lambda e: download_button.configure(text_font=('Arial', 8, 'underline')))
+        download_button.bind('<Leave>', lambda e: download_button.configure(text_font=('Arial', 8)))
+
+        # Don't show new version message again
+        dont_show_button = ctk.CTkButton(self.msg_frame, text='| Don\'t show again', command=lambda: self.dont_show_update_bar_again(dont_show_callback),
+                                         fg_color='blue', text_font=('Arial', 8), hover_color='#0000DD', width=1)
+        dont_show_button.pack(side='left')
+        dont_show_button.bind('<Enter>', lambda e: dont_show_button.configure(text_font=('Arial', 8, 'underline')))
+        dont_show_button.bind('<Leave>', lambda e: dont_show_button.configure(text_font=('Arial', 8)))
+
+        hide_button = ctk.CTkButton(self.msg_frame, text='x', command=self.hide_update_bar, fg_color='blue', text_font=('Arial', 12), hover_color='#0000DD', width=1)
+        hide_button.pack(side='right', padx=5)
+
+    def set_profile_delete_preset(self):
+        pass
+
+
 
 
 class Popup:

--- a/changlelog.md
+++ b/changlelog.md
@@ -1,9 +1,5 @@
 # SMAPI Profile Manager Changelog
 
-## Update v1.2.4 (???)
-
-### Additions
- - Added a check to notify you when a new update is availible
 
 ## QOL Update [v1.2.3] (Jan 26, 2022)
 An update with a lot of small quality of life changes and fixes. The goal is to make the program work as you'd think it would.

--- a/changlelog.md
+++ b/changlelog.md
@@ -1,5 +1,9 @@
 # SMAPI Profile Manager Changelog
 
+## Update v1.2.4 (???)
+
+### Additions
+ - Added a check to notify you when a new update is availible
 
 ## QOL Update [v1.2.3] (Jan 26, 2022)
 An update with a lot of small quality of life changes and fixes. The goal is to make the program work as you'd think it would.

--- a/changlelog.md
+++ b/changlelog.md
@@ -1,5 +1,11 @@
 # SMAPI Profile Manager Changelog
 
+## Update [v1.2.4] (???)
+A slightly more feature heavy update than recently, possibly the last big update until 1.3.0.
+
+### Additions
+ - Added a button to revert the last change to profiles, in case you accidentally deleted one, for example
+ - Added an update check that informs you when a new update is available
 
 ## QOL Update [v1.2.3] (Jan 26, 2022)
 An update with a lot of small quality of life changes and fixes. The goal is to make the program work as you'd think it would.

--- a/main.py
+++ b/main.py
@@ -83,6 +83,7 @@ class Profile:
         editor = ProfileEditor(window, profile_data=self.prof_info, callback=self.load_changed_info)
         window.wait_window(editor.editor)
         profiles_data_old = profiles_data.copy()
+        window.undo_button.configure(state='normal')
         edit_saved_profile(profiles_data, self.name, self.prof_info, action='edit')
         self.name = self.prof_info['name']
         if 'path' in self.prof_info: self.path = self.prof_info['path'].rstrip("\n")
@@ -101,6 +102,7 @@ class Profile:
         self.prof_delete.destroy()
         # Remove the profile from the text file
         profiles_data_old = profiles_data.copy()
+        window.undo_button.configure(state='normal')
         edit_saved_profile(profiles_data, self.name, action='delete')
         profiles.remove(self)
 
@@ -117,6 +119,7 @@ def add_profile():
     if prof_name is not None:
         # Restrict profile name to 100 characters
         profiles_data_old = profiles_data.copy()
+        window.undo_button.configure(state='normal')
         prof_name = prof_name[:100] if len(prof_name) > 100 else prof_name
         profiles.append(Profile({'name': prof_name, 'path': prof_path, 'created': int(time())}))
         profiles[-1].draw_profile()
@@ -181,6 +184,7 @@ def check_for_updates():
 def undo_changes():
     global profiles_data_old, profiles_data
     profiles_data = profiles_data_old
+    window.undo_button.configure(state='disabled')
     save_profile(profiles_data)
     for profile in profiles:
         # Redraw all the profiles in case any were deleted or added

--- a/main.py
+++ b/main.py
@@ -168,7 +168,7 @@ def check_for_updates():
         #  Give up if the request fails
         return
     if latest_release != VERSION:
-        popup = BarPopup(window).preset.set_new_update(latest_release, dont_show_update_bar_again)
+        popup = BarPopup(window).set_update_preset(latest_release, dont_show_update_bar_again)
 
 
 def dont_show_update_bar_again():

--- a/main.py
+++ b/main.py
@@ -168,7 +168,7 @@ def check_for_updates():
         #  Give up if the request fails
         return
     if latest_release != VERSION:
-        popup = BarPopup(window).set_update_preset(latest_release, dont_show_update_bar_again)
+        popup = BarPopup(window).preset.set_new_update(latest_release, dont_show_update_bar_again)
 
 
 def dont_show_update_bar_again():

--- a/main.py
+++ b/main.py
@@ -79,8 +79,10 @@ class Profile:
 
     def edit_profile(self):
         # Launches the profile editor, then applies changes
+        global profiles_data_old
         editor = ProfileEditor(window, profile_data=self.prof_info, callback=self.load_changed_info)
         window.wait_window(editor.editor)
+        profiles_data_old = profiles_data.copy()
         edit_saved_profile(profiles_data, self.name, self.prof_info, action='edit')
         self.name = self.prof_info['name']
         if 'path' in self.prof_info: self.path = self.prof_info['path'].rstrip("\n")
@@ -92,24 +94,29 @@ class Profile:
 
     def delete_profile(self):
         # Remove profile widgets, then remove profile from the save file
+        global profiles_data_old
         self.prof_frame.destroy()
         self.prof_title.destroy()
         self.prof_button.destroy()
         self.prof_delete.destroy()
         # Remove the profile from the text file
+        profiles_data_old = profiles_data.copy()
         edit_saved_profile(profiles_data, self.name, action='delete')
+        profiles.remove(self)
 
 
 def add_profile():
     # Add a new profile (top right button)
+    global profiles_data_old
     prof_path = filedialog.askdirectory()
     if prof_path == '': return
     popup = Popup("Name your profile", "Enter a name for your profile", window, callback=return_popup_info)
     window.wait_window(popup.popup)
     # Gets the information from the popup (profile name)
     prof_name = popup_info['name']
-    if prof_name != None:
+    if prof_name is not None:
         # Restrict profile name to 100 characters
+        profiles_data_old = profiles_data.copy()
         prof_name = prof_name[:100] if len(prof_name) > 100 else prof_name
         profiles.append(Profile({'name': prof_name, 'path': prof_path, 'created': int(time())}))
         profiles[-1].draw_profile()
@@ -171,6 +178,17 @@ def check_for_updates():
         window.update_bar(latest_release, dont_show_update_bar_again)
 
 
+def undo_changes():
+    global profiles_data_old, profiles_data
+    profiles_data = profiles_data_old
+    save_profile(profiles_data)
+    for profile in profiles:
+        # Redraw all the profiles in case any were deleted or added
+        profile.hide_profile()
+        profile.draw_profile()
+        sort_profiles(settings['sort'])
+
+
 def dont_show_update_bar_again():
     settings['show_update_bar'] = False
     save_settings(settings)
@@ -197,6 +215,7 @@ if __name__ == '__main__':
     windll.user32.SetProcessDPIAware()
     window = Window(settings, sort_callback=sort_profiles)
     window.add_prof_button.configure(command=add_profile)
+    window.undo_button.configure(command=undo_changes)
 
     # Check for the SMAPI executable and prompt user if not found
     if 'smapi_path' not in settings or not os.path.exists(settings['smapi_path']):
@@ -210,6 +229,7 @@ if __name__ == '__main__':
 
     if os.path.exists('profiles.txt'): profiles_data = convert_legacy_profiles(profiles_data)
     profiles_data = load_profiles()
+    profiles_data_old = profiles_data.copy()
     # Make sure the unmodded profile is added to the save
     if profiles_data == []:
         profiles_data.insert(0, {'name': 'Unmodded', 'force_smapi': False, 'special': 'unmodded', 'created': int(time())})

--- a/main.py
+++ b/main.py
@@ -187,10 +187,12 @@ def undo_changes():
     window.undo_button.configure(state='disabled')
     save_profile(profiles_data)
     for profile in profiles:
-        # Redraw all the profiles in case any were deleted or added
         profile.hide_profile()
-        profile.draw_profile()
-        sort_profiles(settings['sort'])
+    profiles.clear()
+    for profile in profiles_data:
+        profiles.append(Profile(profile))
+        profiles[-1].draw_profile()
+    sort_profiles(settings['sort'])
 
 
 def dont_show_update_bar_again():

--- a/main.py
+++ b/main.py
@@ -168,7 +168,7 @@ def check_for_updates():
         #  Give up if the request fails
         return
     if latest_release != VERSION:
-        popup = BarPopup(window).set_update_preset(latest_release, dont_show_update_bar_again)
+        window.update_bar(latest_release, dont_show_update_bar_again)
 
 
 def dont_show_update_bar_again():
@@ -178,7 +178,7 @@ def dont_show_update_bar_again():
 
 profiles = []
 name_input = ''
-VERSION = "v1.2.2"
+VERSION = "v1.2.3"
 
 if __name__ == '__main__':
     check_files()

--- a/main.py
+++ b/main.py
@@ -168,7 +168,7 @@ def check_for_updates():
         #  Give up if the request fails
         return
     if latest_release != VERSION:
-        window.update_bar(latest_release, dont_show_update_bar_again)
+        popup = BarPopup(window).set_update_preset(latest_release, dont_show_update_bar_again)
 
 
 def dont_show_update_bar_again():
@@ -178,7 +178,7 @@ def dont_show_update_bar_again():
 
 profiles = []
 name_input = ''
-VERSION = "v1.2.3"
+VERSION = "v1.2.2"
 
 if __name__ == '__main__':
     check_files()


### PR DESCRIPTION
Closes #30 

This PR would allow deleted profiles to be reverted for a few seconds after they are deleted to prevent accidentally deleting profiles permanently.

 - [x] Add undo changes button to control panel
 - [x] Create profiles backup
 - [x] Revert changes in profile data
 - [x] Update changelog