### PR TITLE
Allow profiles to be pinned to the top of the list

### DIFF
--- a/ProfileManager/SuperWidgets/ProfileEditor.py
+++ b/ProfileManager/SuperWidgets/ProfileEditor.py
@@ -43,6 +43,11 @@ class ProfileEditor:
             self.eForceSMAPI = self.editable_true_false('Force SMAPI:')[2]
             self.eForceSMAPI.select() if self.prof_info['force_smapi'] else self.eForceSMAPI.deselect()
 
+        # Pin profile
+        self.ePin = self.editable_true_false('Pin:')[2]
+        if 'pinned' in self.prof_info:
+            self.ePin.select() if self.prof_info['pinned'] else self.ePin.deselect()
+
         self.properties_dropdown = ctk.CTkButton(self.editor, text=('\U000023AF' * 4) + ' Properties v ' + ('\U000023AF' * 25), width=10,
                                                  command=self.dropdown_manager, fg_color='gray18', hover_color='gray22')
         self.properties_dropdown.pack(pady=(10, 0))
@@ -111,10 +116,10 @@ class ProfileEditor:
         # Apply changes to the profile by calling the callback function in main.py
         if self.prof_info['special'] == None:
             self.callback({'name': self.eName.get(), 'path': self.ePathEntry.get(), 'created': self.prof_info['created'],
-                           'last_launched': self.prof_info['last_launched'], 'special': None})
+                           'last_launched': self.prof_info['last_launched'], 'special': None, 'pinned': self.ePin.get()})
         elif self.prof_info['special'] == 'unmodded':
             self.callback({'name': self.eName.get(), 'special': 'unmodded', 'force_smapi': self.eForceSMAPI.get(), 'created': self.prof_info['created'],
-                           'last_launched': self.prof_info['last_launched']})
+                           'last_launched': self.prof_info['last_launched'], 'pinned': self.ePin.get()})
         self.editor.destroy()
 
     def browse_path(self):

--- a/ProfileManager/main.py
+++ b/ProfileManager/main.py
@@ -144,14 +144,18 @@ def sort_profiles(sort=None):
     # Manages profile sorting
     invert = window.invert_sort_checkbox.get()
     # Save the unmodded profile to local var unmodded
-    unmodded = profiles[0]
-    # Remove unmodded profile from profiles list
-    profiles.pop(0)
+    pinned = []
+    for profile in profiles:
+        if 'pinned' in profile.prof_info:
+            if profile.prof_info['pinned']:
+                pinned.append(profile)
+                profiles.pop(profiles.index(profile))
     if sort is None:
         # If the sorting method didn't change, but invert was toggled
         profiles.reverse()
         # Re-insert the unmodded profile back at position 0
-        profiles.insert(0, unmodded)
+        for profile in pinned:
+            profiles.insert(0, profile)
     else:
         # If the sorting method does change...
         if sort == 'Name':
@@ -161,7 +165,8 @@ def sort_profiles(sort=None):
         elif sort == 'Last Played':
             profiles.sort(key=lambda x: x.last_launched, reverse=invert)
         # Re-insert the unmodded profile back at position 0
-        profiles.insert(0, unmodded)
+        for profile in pinned:
+            profiles.insert(0, profile)
     # Un-pack all the profiles first...
     for profile in profiles:
         profile.hide_profile()

--- a/ProfileManager/main.py
+++ b/ProfileManager/main.py
@@ -34,6 +34,7 @@ class Profile:
         self.left_frame.pack_propagate(False)
         self.right_frame = ctk.CTkFrame(self.prof_frame, width=140, height=32, fg_color='gray21', bg_color='gray21')
         self.right_frame.pack_propagate(False)
+        self.prof_pin = ctk.CTkLabel(self.left_frame, text="\U0001F4CC", text_color="gray6", text_font=("Arial", 12), width=1)
         self.prof_title = ctk.CTkLabel(self.left_frame, text=self.name, fg_color="gray21", text_font=("Arial", 12), anchor='w')
         self.prof_button = Button(self.right_frame, text="\U000025B6", fg_color="gray21", text_font=("Arial", 24), text_color='white', hover_color='gray21', width=32, command=self.select_profile)
         self.prof_edit = Button(self.right_frame, width=32, image=window.icons.gear, fg_color="gray21", height=40, type='button', text_color='white', hover_image=window.icons.gear_dark, command=self.edit_profile)
@@ -44,12 +45,18 @@ class Profile:
         self.edit_tooltip = Tooltip(self.prof_edit, "Edit this profile")
         self.delete_tooltip = Tooltip(self.prof_delete, "Delete this profile")
         self.name_tooltip = Tooltip(self.prof_title, self.name)
+        self.pin_tooltip = Tooltip(self.prof_pin, "This profile is pinned to the top of the list")
 
     def draw_profile(self):
         # Pack all profile widgets
         self.prof_frame.pack(pady=2)
-        self.left_frame.pack(side='left', padx=(10, 0))
-        self.prof_title.pack(side=ctk.LEFT, padx=(20, 10))
+        if 'pinned' in self.prof_info and self.prof_info['pinned']:
+            self.left_frame.pack(side='left')
+            self.prof_pin.pack(side=ctk.LEFT, padx=(7,3))
+            self.prof_title.pack(side=ctk.LEFT, padx=(0, 10))
+        else:
+            self.left_frame.pack(side='left', padx=(10, 0))
+            self.prof_title.pack(side=ctk.LEFT, padx=(20, 10))
         self.prof_button.pack(side=ctk.RIGHT, padx=(8, 4))
         self.prof_edit.pack(side=ctk.RIGHT, padx=(8, 0))
         if self.special != 'unmodded': self.prof_delete.pack(side=ctk.RIGHT)

--- a/ProfileManager/main.py
+++ b/ProfileManager/main.py
@@ -245,9 +245,9 @@ if __name__ == '__main__':
     profiles_data_old = profiles_data.copy()
     # Make sure the unmodded profile is added to the save
     if not profiles_data:
-        profiles_data.insert(0, {'name': 'Unmodded', 'force_smapi': False, 'special': 'unmodded', 'created': int(time())})
+        profiles_data.insert(0, {'name': 'Unmodded', 'force_smapi': False, 'special': 'unmodded', 'created': int(time()), 'pinned': 1})
     elif 'force_smapi' not in profiles_data[0]:
-        profiles_data.insert(0, {'name': 'Unmodded', 'force_smapi': False, 'special': 'unmodded', 'created': int(time())})
+        profiles_data.insert(0, {'name': 'Unmodded', 'force_smapi': False, 'special': 'unmodded', 'created': int(time()), 'pinned': 1})
     for profile in profiles_data:
         profiles.append(Profile(profile))
     sort_profiles(settings['sort']) if 'sort' in settings else sort_profiles('Name')

--- a/changlelog.md
+++ b/changlelog.md
@@ -6,7 +6,7 @@ A slightly more feature heavy update than recently, possibly the last big update
 ### Additions
  - Added a button to revert the last change to profiles, in case you accidentally deleted one, for example (#33)
  - Added an update check that informs you when a new update is available (#32)
- - 
+ - Profiles can now be pinned to the top of the list (#34)
 
 ### Changes
  - Massively reorganized the code to make it easier to work with

--- a/changlelog.md
+++ b/changlelog.md
@@ -6,6 +6,7 @@ A slightly more feature heavy update than recently, possibly the last big update
 ### Additions
  - Added a button to revert the last change to profiles, in case you accidentally deleted one, for example (#33)
  - Added an update check that informs you when a new update is available (#32)
+ - 
 
 ### Changes
  - Massively reorganized the code to make it easier to work with


### PR DESCRIPTION
Closes #31 

This PR would allow profiles to be pinned to the top of the profiles list to make it easier to find your favorite profiles.

 - [x] Create new profile setting for pinning
 - [x] Modify profile sorter to put sorted profiles at the top
 - [x] Add pin icon to pinned profiles
 - [x] Update changelog